### PR TITLE
fix(subagent): 升序模式下新条目加入时自动保持在最新位置

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1058,6 +1058,27 @@ function SubAgentPanel(props: {
     try { persistScroll(props.sessionId, target) } catch {}
   })
 
+  // When new entries arrive while viewing the newest end, keep the view at newest
+  let prevEntryCount = 0
+  createEffect(() => {
+    const total = entryList().length
+    if (prevEntryCount === 0) { prevEntryCount = total; return }
+    if (total === prevEntryCount) return
+
+    const m = max()
+    const wasAtNewest = props.sortOrder() === "desc"
+      ? untrack(() => scrollOffset() === 0)
+      : untrack(() => scrollOffset() >= prevEntryCount - m)
+
+    prevEntryCount = total
+
+    if (wasAtNewest) {
+      const target = props.sortOrder() === "desc" ? 0 : Math.max(0, total - m)
+      setScrollOffset(target)
+      try { persistScroll(props.sessionId, target) } catch {}
+    }
+  })
+
   const entries = createMemo(() => {
     const nowVal = now()
     return entryList().map((e) => ({


### PR DESCRIPTION
修复 createEffect 中 untrack 排除了 entryList 依赖追踪的问题。新增独立 effect 追踪 entryList 长度变化：降序在顶部时自动保持，升序在底部时自动保持。