### PR TITLE
fix(subagent): 排序切换后延迟 persistScroll 避免干扰点击翻页

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1068,7 +1068,9 @@ function SubAgentPanel(props: {
     const m = untrack(() => max())
     const target = props.sortOrder() === "desc" ? 0 : Math.max(0, total - m)
     setScrollOffset(target)
-    try { persistScroll(props.sessionId, target) } catch {}
+    setTimeout(() => {
+      try { persistScroll(props.sessionId, target) } catch {}
+    }, 0)
   })
 
   // When new entries arrive while viewing the newest end, keep the view at newest
@@ -1088,7 +1090,9 @@ function SubAgentPanel(props: {
     if (wasAtNewest) {
       const target = props.sortOrder() === "desc" ? 0 : Math.max(0, total - m)
       setScrollOffset(target)
-      try { persistScroll(props.sessionId, target) } catch {}
+      setTimeout(() => {
+        try { persistScroll(props.sessionId, target) } catch {}
+      }, 0)
     }
   })
 


### PR DESCRIPTION
sortOrder effect 中同步 persistScroll 写 KV 可能在 Solid 渲染批次中干扰 more 按钮的状态读取，导致点击模式下 more 无响应。将 persistScroll 用 setTimeout 延迟到下一帧执行。