### PR TITLE
feat: 嵌套 KV 结构 + 可配置 TTL + 条目清除

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@
 - **滚动回顶/回底**：列表底部 `↑ 回顶` / `↓ 回底` 按钮一键跳转到最新条目位置，方向随排序自适应
 - **可配置排序**：`/subagent-order` 支持「降序（最新在前）」和「升序（最早在前）」两种排列方式
 - **翻页模式切换**：`/subagent-scroll` 可选「滚轮翻页」或「点击 more 翻页」，解决侧边栏与全局滚动冲突
-- **TTL 自动清理**：超过 3 天的旧数据自动从 KV 中清除
+- **TTL 自动清理**：可配置数据保留期限（3/7/14/30 天/无期限），每次访问自动续期，过期自动清除
+- **手动清除条目**：`/subagent-clear-entries` 清除当前会话所有记录，防止历史条目扫描重建
 - **语言适配**：支持 `/subagent-lang` 运行时切换中/英文，偏好持久化
-- **斜杠命令**：`/subagent-lang` `/subagent-max` `/subagent-order` `/subagent-scroll` `/subagent-session` `/subagent-version` `/subagent-clear-running` 动态配置
+- **斜杠命令**：`/subagent-lang` `/subagent-max` `/subagent-order` `/subagent-scroll` `/subagent-ttl` `/subagent-clear-entries` `/subagent-session` `/subagent-version` `/subagent-clear-running` 动态配置
 
 ---
 
@@ -108,6 +109,8 @@ npm install -g opencode-subagent-magazine@latest
 | `/subagent-max` | 调整最大可见条目数 | 输入数字（默认 10），控制面板最多显示多少个子代理条目 |
 | `/subagent-order` | 切换排序方式 | 选择「降序（最新在前）」或「升序（最早在前）」，即时重排并跳转到最新条目 |
 | `/subagent-scroll` | 切换翻页模式 | 选择「滚轮翻页」或「点击 more 翻页」，解决与全局滚动冲突 |
+| `/subagent-ttl` | 设置数据保留期限 | 选择 3 天 / 7 天 / 14 天 / 30 天 / 无期限，控制 KV 自动清理间隔 |
+| `/subagent-clear-entries` | 清除当前会话记录 | 确认后删除所有子代理记录，阻止扫描重建历史条目 |
 | `/subagent-session` | 查看当前会话 ID | 弹出当前 OpenCode 会话 ID |
 | `/subagent-version` | 查看插件版本 | 弹出当前插件版本号 |
 | `/subagent-clear-running` | 批量清理僵尸条目 | 一键将所有运行中的条目标记为完成，清理卡住的旧数据 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,9 +53,10 @@ Interested in token cache visualization? Check out [opencode-visual-cache](https
 - **Scroll to Newest**: `↑ Top` / `↓ Bottom` button jumps to the newest entries; direction adapts to sort order
 - **Configurable Sort Order**: `/subagent-order` supports descending (newest first) and ascending (oldest first) ordering
 - **Scroll Mode Toggle**: `/subagent-scroll` switches between wheel scroll and click-to-scroll (click `↑ more` / `↓ more` to page), resolving sidebar/global scroll conflicts
-- **TTL Auto Cleanup**: Data older than 3 days is automatically purged from KV storage
+- **TTL Auto Cleanup**: Configurable retention period (3/7/14/30 days or Never), auto-refreshed on access, expired data purged automatically
+- **Manual Entry Clear**: `/subagent-clear-entries` removes all records for the current session and prevents scan re-creation of historical entries
 - **Language Support**: Runtime language switch via `/subagent-lang` (Chinese / English), preference persisted
-- **Slash Commands**: `/subagent-lang`, `/subagent-max`, `/subagent-order`, `/subagent-scroll`, `/subagent-session`, `/subagent-version`, `/subagent-clear-running` for dynamic configuration
+- **Slash Commands**: `/subagent-lang`, `/subagent-max`, `/subagent-order`, `/subagent-scroll`, `/subagent-ttl`, `/subagent-clear-entries`, `/subagent-session`, `/subagent-version`, `/subagent-clear-running` for dynamic configuration
 
 ---
 
@@ -108,6 +109,8 @@ The plugin supports dynamic configuration via slash commands or the command pale
 | `/subagent-max` | Adjust max visible entries | Enter a number (default 10) to control how many sub-agent entries are shown |
 | `/subagent-order` | Switch sort order | Choose descending (newest first) or ascending (oldest first); list re-sorts and jumps to newest |
 | `/subagent-scroll` | Switch scroll mode | Choose wheel scroll or click-to-scroll (click `↑ more` / `↓ more` to page) |
+| `/subagent-ttl` | Set data retention period | Choose 3 / 7 / 14 / 30 days or Never to control KV auto-cleanup interval |
+| `/subagent-clear-entries` | Clear current session records | Confirms then deletes all sub-agent records, preventing scan re-creation of historical entries |
 | `/subagent-session` | View current session ID | Displays the current OpenCode session ID |
 | `/subagent-version` | View plugin version | Displays the current plugin version |
 | `/subagent-clear-running` | Batch cleanup stuck entries | Marks all running entries as done in one click, cleaning up stale data |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,6 +81,16 @@ const I18N: Record<Lang, Record<string, string>> = {
     "order.asc": "升序（最早在前）",
     "scroll.wheel": "滚轮翻页",
     "scroll.click": "点击翻页",
+    "ttl.label": "清理周期",
+    "ttl.3d": "3 天",
+    "ttl.7d": "7 天",
+    "ttl.14d": "14 天",
+    "ttl.30d": "30 天",
+    "ttl.toast": "清理周期已设为 {n} 天",
+    "clear.title": "确认清除",
+    "clear.prompt": "确定清除当前会话所有子代理记录？此操作不可撤销。",
+    "clear.done": "已清除 {n} 条子代理记录",
+    "clear.empty": "当前会话无子代理记录",
   },
   en: {
     "panel.title": "SubAgent",
@@ -107,6 +117,16 @@ const I18N: Record<Lang, Record<string, string>> = {
     "order.asc": "Asc (oldest first)",
     "scroll.wheel": "Wheel Scroll",
     "scroll.click": "Click Scroll",
+    "ttl.label": "TTL",
+    "ttl.3d": "3 days",
+    "ttl.7d": "7 days",
+    "ttl.14d": "14 days",
+    "ttl.30d": "30 days",
+    "ttl.toast": "TTL set to {n} days",
+    "clear.title": "Confirm",
+    "clear.prompt": "Clear all sub-agent records for this session? This cannot be undone.",
+    "clear.done": "Cleared {n} sub-agent record(s)",
+    "clear.empty": "No sub-agent records in this session",
   },
 }
 
@@ -279,7 +299,8 @@ function SubAgentPanel(props: {
 
   // ── session data (single-key, true deletion on cleanup) ──
   const SESSION_DATA_KEY = `${KV_PREFIX}.session_data`
-  const TTL_MS = 3 * 24 * 60 * 60 * 1000
+  const ttlDays = parseInt(String(props.api.kv.get(`${KV_PREFIX}.ttl_days`, "3")), 10) || 3
+  const TTL_MS = ttlDays * 24 * 60 * 60 * 1000
 
   interface ChildRecord {
     scroll: number
@@ -1879,6 +1900,76 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
           api.ui.toast({ message: msg })
         }
         dialog?.clear()
+      },
+    },
+    {
+      title: "SubAgent Magazine: TTL",
+      value: "subagent-ttl",
+      description: "Set session data retention period (days before auto-cleanup)",
+      slash: { name: "subagent-ttl" },
+      onSelect: (dialog) => {
+        const t = (k: string) => I18N[signals.lang()][k] ?? k
+        dialog?.replace(() => (
+          <api.ui.DialogSelect
+            title={t("ttl.label")}
+            options={[
+              { title: t("ttl.3d"), value: "3" },
+              { title: t("ttl.7d"), value: "7" },
+              { title: t("ttl.14d"), value: "14" },
+              { title: t("ttl.30d"), value: "30" },
+            ]}
+            onSelect={(opt) => {
+              const days = parseInt(opt.value, 10)
+              api.kv.set(`${KV_PREFIX}.ttl_days`, String(days))
+              const msg = t("ttl.toast").replace("{n}", String(days))
+              api.ui.toast({ message: msg })
+              dialog?.clear()
+            }}
+          />
+        ))
+      },
+    },
+    {
+      title: "SubAgent Magazine: Clear Entries",
+      value: "subagent-clear-entries",
+      description: "Delete all sub-agent records for the current session (cannot be undone)",
+      slash: { name: "subagent-clear-entries" },
+      onSelect: (dialog) => {
+        const t = (k: string) => I18N[signals.lang()][k] ?? k
+        const sid = signals.sessionId
+        const sessionObj = api.state.session.get(sid)
+        const parentID = (sessionObj as any)?.parentID as string | undefined
+        dialog?.replace(() => (
+          <api.ui.DialogConfirm
+            title={t("clear.title")}
+            message={t("clear.prompt")}
+            onConfirm={() => {
+              try {
+                const data = JSON.parse(String(api.kv.get(`${KV_PREFIX}.session_data`, "{}")))
+                let count = 0
+                if (parentID) {
+                  if (data[parentID]?.children?.[sid]) {
+                    count = data[parentID].children[sid].entries?.length ?? 0
+                    data[parentID].children[sid].entries = []
+                    data[parentID].children[sid].scroll = 0
+                    data[parentID].children[sid].expanded = ""
+                  }
+                } else {
+                  count = data[sid]?.entries?.length ?? 0
+                  if (data[sid]) {
+                    data[sid].entries = []
+                    data[sid].scroll = 0
+                    data[sid].expanded = ""
+                  }
+                }
+                api.kv.set(`${KV_PREFIX}.session_data`, JSON.stringify(data))
+                const msg = t("clear.done").replace("{n}", String(count))
+                api.ui.toast({ message: msg })
+              } catch {}
+              dialog?.clear()
+            }}
+          />
+        ))
       },
     },
   ])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -982,13 +982,16 @@ function SubAgentPanel(props: {
   // On session change: load from kv (entries survive component unmount), then scan+merge.
   // On same session: only scan+merge (keep event‑driven running entries).
   let lastSid = props.sessionId
+  let lastTick = 0
   createEffect(() => {
     const sid = props.sessionId
     const switched = sid !== lastSid
     lastSid = sid
+    const tick = clearTick()    // 外部触发清除时 +1，effect 重跑
+    const forceReload = tick !== lastTick && !switched
+    lastTick = tick
     const t = setTimeout(() => {
       untrack(() => {
-        void clearTick() // 外部触发的清除事件 → 重扫
         if (switched) {
           const { parentSid, isChild } = resolveParent(sid)
           const data = loadSessionData()
@@ -1006,7 +1009,7 @@ function SubAgentPanel(props: {
         // Only event-driven changes (handlePartUpdated, handleSessionEnd) persist.
         setEntryMapRaw((prev) => {
           // 优先从模块级缓存加载，KV 仅作缓存未命中时的回退
-          const next = switched
+          const next = (switched || forceReload)
             ? new Map(globalEntryCache.get(sid) ?? loadEntries(sid))
             : new Map(prev)
           // 从 KV 加载当前会话的清除名单，扫描时跳过被手动清除的历史条目

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,7 +309,7 @@ function SubAgentPanel(props: {
     scroll: number
     expanded: string
     entries: SubEntry[]
-    cleared?: boolean
+    clearedIds?: string[]
   }
 
   interface SessionRecord {
@@ -318,7 +318,7 @@ function SubAgentPanel(props: {
     scroll: number
     expanded: string
     children: Record<string, ChildRecord>
-    cleared?: boolean
+    clearedIds?: string[]
   }
 
   const loadSessionData = (): Record<string, SessionRecord> => {
@@ -369,9 +369,9 @@ function SubAgentPanel(props: {
           if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
           if (!data[parentSid].children) data[parentSid].children = {}
           if (!data[parentSid].children[sid]) data[parentSid].children[sid] = { scroll: 0, expanded: "", entries: [] }
-          data[parentSid].children[sid] = { ...data[parentSid].children[sid], entries: [...entries.values()], cleared: false }
+          data[parentSid].children[sid] = { ...data[parentSid].children[sid], entries: [...entries.values()] }
         } else {
-          data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()], children: data[sid]?.children ?? {}, cleared: false }
+          data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()], children: data[sid]?.children ?? {} }
         }
         saveSessionData(data)
       } catch {}
@@ -456,9 +456,9 @@ function SubAgentPanel(props: {
             if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
             if (!data[parentSid].children) data[parentSid].children = {}
             if (!data[parentSid].children[props.sessionId]) data[parentSid].children[props.sessionId] = { scroll: 0, expanded: "", entries: [] }
-            data[parentSid].children[props.sessionId] = { ...data[parentSid].children[props.sessionId], entries: [...next.values()], cleared: false }
+            data[parentSid].children[props.sessionId] = { ...data[parentSid].children[props.sessionId], entries: [...next.values()] }
           } else {
-            data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()], children: data[props.sessionId]?.children ?? {}, cleared: false }
+            data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()], children: data[props.sessionId]?.children ?? {} }
           }
           saveSessionData(data)
         } catch {}
@@ -1003,11 +1003,10 @@ function SubAgentPanel(props: {
           const next = switched
             ? new Map(globalEntryCache.get(sid) ?? loadEntries(sid))
             : new Map(prev)
-          // 被手动清除的会话跳过消息扫描重建，仅保留事件驱动新增的条目
-          const { parentSid, isChild } = resolveParent(sid)
-          const parentRec = loadSessionData()[parentSid]
-          const activeRec = isChild ? parentRec?.children?.[sid] : parentRec
-          if (activeRec?.cleared) return next
+          // 从 KV 加载当前会话的清除名单，扫描时跳过被手动清除的历史条目
+          const { parentSid: scanPSid, isChild: scanChild } = resolveParent(sid)
+          const scanRec = loadSessionData()[scanPSid]
+          const clearedIds = new Set(scanChild ? scanRec?.children?.[sid]?.clearedIds : scanRec?.clearedIds)
           try {
             const msgs = props.api.state.session.messages(sid)
             if (msgs && (msgs as any[]).length) {
@@ -1027,6 +1026,9 @@ function SubAgentPanel(props: {
                     const st = (part as any).state as Record<string, unknown> | undefined
                     const rawStatus = String(st?.status ?? "")
                     const exists = next.get(id)
+
+                    // 已手动清除的条目：scan 发现但不在内存 → 跳过重建
+                    if (!exists && clearedIds.has(id)) continue
 
                     // Only create entries for tool calls that entered execution.
                     // "pending" / empty: skip new entries; allow heuristics for existing ones below.
@@ -1960,19 +1962,22 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
                 let count = 0
                 if (parentID) {
                   if (data[parentID]?.children?.[sid]) {
-                    count = data[parentID].children[sid].entries?.length ?? 0
-                    data[parentID].children[sid].entries = []
-                    data[parentID].children[sid].scroll = 0
-                    data[parentID].children[sid].expanded = ""
-                    data[parentID].children[sid].cleared = true
+                    const child = data[parentID].children[sid]
+                    const ids = child.entries?.map((e: any) => e.id) ?? []
+                    count = ids.length
+                    child.entries = []
+                    child.scroll = 0
+                    child.expanded = ""
+                    child.clearedIds = [...new Set([...(child.clearedIds ?? []), ...ids])]
                   }
                 } else {
                   count = data[sid]?.entries?.length ?? 0
                   if (data[sid]) {
+                    const ids = data[sid].entries?.map((e: any) => e.id) ?? []
                     data[sid].entries = []
                     data[sid].scroll = 0
                     data[sid].expanded = ""
-                    data[sid].cleared = true
+                    data[sid].clearedIds = [...new Set([...(data[sid].clearedIds ?? []), ...ids])]
                   }
                 }
                 api.kv.set(`${KV_PREFIX}.session_data`, JSON.stringify(data))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,7 @@ const I18N: Record<Lang, Record<string, string>> = {
     "order.asc": "Asc (oldest first)",
     "scroll.wheel": "Wheel Scroll",
     "scroll.click": "Click Scroll",
-    "ttl.label": "TTL",
+    "ttl.label": "TTL (Time to Live)",
     "ttl.3d": "3 days",
     "ttl.7d": "7 days",
     "ttl.14d": "14 days",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1928,9 +1928,12 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
       slash: { name: "subagent-ttl" },
       onSelect: (dialog) => {
         const t = (k: string) => I18N[signals.lang()][k] ?? k
+        const curRaw = parseInt(String(api.kv.get(`${KV_PREFIX}.ttl_days`, "3")), 10)
+        const curDays = Number.isNaN(curRaw) ? 3 : curRaw
+        const curLabel = curDays === 0 ? t("ttl.unlimited") : `${curDays}d`
         dialog?.replace(() => (
           <api.ui.DialogSelect
-            title={t("ttl.label")}
+            title={`${t("ttl.label")}  (${curLabel})`}
             options={[
               { title: t("ttl.3d"), value: "3" },
               { title: t("ttl.7d"), value: "7" },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -281,11 +281,18 @@ function SubAgentPanel(props: {
   const SESSION_DATA_KEY = `${KV_PREFIX}.session_data`
   const TTL_MS = 3 * 24 * 60 * 60 * 1000
 
+  interface ChildRecord {
+    scroll: number
+    expanded: string
+    entries: SubEntry[]
+  }
+
   interface SessionRecord {
     ts: number
     entries: SubEntry[]
     scroll: number
     expanded: string
+    children: Record<string, ChildRecord>
   }
 
   const loadSessionData = (): Record<string, SessionRecord> => {
@@ -299,12 +306,27 @@ function SubAgentPanel(props: {
     try { props.api.kv.set(SESSION_DATA_KEY, JSON.stringify(data)) } catch {}
   }
 
+  /** 将任意 session ID 解析为父会话 ID + 是否子会话。
+   *  通过 SDK session.get(sid).parentID 判断，无 parentID 即为主会话。 */
+  const resolveParent = (sid: string): { parentSid: string; isChild: boolean } => {
+    try {
+      const session = props.api.state.session.get(sid)
+      const parentID = (session as any)?.parentID as string | undefined
+      if (parentID) return { parentSid: parentID, isChild: true }
+    } catch {}
+    return { parentSid: sid, isChild: false }
+  }
+
   const loadEntries = (sid: string): Map<string, SubEntry> => {
     const m = new Map<string, SubEntry>()
     try {
-      const rec = loadSessionData()[sid]
-      if (rec?.entries) {
-        for (const e of rec.entries) m.set(e.id, e)
+      const { parentSid, isChild } = resolveParent(sid)
+      const rec = loadSessionData()[parentSid]
+      if (rec) {
+        const source = isChild ? rec.children?.[sid]?.entries : rec.entries
+        if (source) {
+          for (const e of source) m.set(e.id, e)
+        }
       }
     } catch {}
     return m
@@ -316,7 +338,15 @@ function SubAgentPanel(props: {
     persistTimer = setTimeout(() => {
       try {
         const data = loadSessionData()
-        data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()] }
+        const { parentSid, isChild } = resolveParent(sid)
+        if (isChild) {
+          if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
+          if (!data[parentSid].children) data[parentSid].children = {}
+          if (!data[parentSid].children[sid]) data[parentSid].children[sid] = { scroll: 0, expanded: "", entries: [] }
+          data[parentSid].children[sid] = { ...data[parentSid].children[sid], entries: [...entries.values()] }
+        } else {
+          data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()], children: data[sid]?.children ?? {} }
+        }
         saveSessionData(data)
       } catch {}
     }, 200)
@@ -325,7 +355,15 @@ function SubAgentPanel(props: {
   const persistScroll = (sid: string, scroll: number) => {
     try {
       const data = loadSessionData()
-      data[sid] = { ...data[sid], ts: Date.now(), scroll }
+      const { parentSid, isChild } = resolveParent(sid)
+      if (isChild) {
+        if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
+        if (!data[parentSid].children) data[parentSid].children = {}
+        if (!data[parentSid].children[sid]) data[parentSid].children[sid] = { scroll: 0, expanded: "", entries: [] }
+        data[parentSid].children[sid] = { ...data[parentSid].children[sid], scroll }
+      } else {
+        data[sid] = { ...data[sid], ts: Date.now(), scroll, children: data[sid]?.children ?? {} }
+      }
       saveSessionData(data)
     } catch {}
   }
@@ -333,7 +371,15 @@ function SubAgentPanel(props: {
   const persistExpanded = (sid: string, expanded: string) => {
     try {
       const data = loadSessionData()
-      data[sid] = { ...data[sid], ts: Date.now(), expanded }
+      const { parentSid, isChild } = resolveParent(sid)
+      if (isChild) {
+        if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
+        if (!data[parentSid].children) data[parentSid].children = {}
+        if (!data[parentSid].children[sid]) data[parentSid].children[sid] = { scroll: 0, expanded: "", entries: [] }
+        data[parentSid].children[sid] = { ...data[parentSid].children[sid], expanded }
+      } else {
+        data[sid] = { ...data[sid], ts: Date.now(), expanded, children: data[sid]?.children ?? {} }
+      }
       saveSessionData(data)
     } catch {}
   }
@@ -379,7 +425,15 @@ function SubAgentPanel(props: {
         clearTimeout(persistTimer)
         try {
           const data = loadSessionData()
-          data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()] }
+          const { parentSid, isChild } = resolveParent(props.sessionId)
+          if (isChild) {
+            if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
+            if (!data[parentSid].children) data[parentSid].children = {}
+            if (!data[parentSid].children[props.sessionId]) data[parentSid].children[props.sessionId] = { scroll: 0, expanded: "", entries: [] }
+            data[parentSid].children[props.sessionId] = { ...data[parentSid].children[props.sessionId], entries: [...next.values()] }
+          } else {
+            data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()], children: data[props.sessionId]?.children ?? {} }
+          }
           saveSessionData(data)
         } catch {}
       } else {
@@ -398,7 +452,14 @@ function SubAgentPanel(props: {
     (() => { try { return props.api.kv.get(`${KV_PREFIX}.open`, true) as boolean } catch { return true } })()
   )
   const [expanded, setExpanded] = createSignal<string | undefined>(
-    (() => { try { return loadSessionData()[props.sessionId]?.expanded || undefined } catch { return undefined } })()
+    (() => {
+      try {
+        const { parentSid, isChild } = resolveParent(props.sessionId)
+        const rec = loadSessionData()[parentSid]
+        if (rec) return isChild ? rec.children?.[props.sessionId]?.expanded || undefined : rec.expanded || undefined
+      } catch {}
+      return undefined
+    })(),
   )
   const [hoveredOpen, setHoveredOpen] = createSignal<string | undefined>(undefined)
   const [hoveredDismiss, setHoveredDismiss] = createSignal<string | undefined>(undefined)
@@ -406,7 +467,13 @@ function SubAgentPanel(props: {
   const [hoveredMoreAbove, setHoveredMoreAbove] = createSignal(false)
   const [hoveredMoreBelow, setHoveredMoreBelow] = createSignal(false)
   const [scrollOffset, setScrollOffset] = createSignal(
-    (() => { try { return loadSessionData()[props.sessionId]?.scroll ?? 0 } catch { return 0 } })()
+    (() => {
+      try {
+        const { parentSid, isChild } = resolveParent(props.sessionId)
+        const rec = loadSessionData()[parentSid]
+        return isChild ? rec?.children?.[props.sessionId]?.scroll ?? 0 : rec?.scroll ?? 0
+      } catch { return 0 }
+    })(),
   )
   const [now, setNow] = createSignal(Date.now())
   const [renderTick, setRenderTick] = createSignal(0)
@@ -890,8 +957,17 @@ function SubAgentPanel(props: {
     const t = setTimeout(() => {
       untrack(() => {
         if (switched) {
-          const saved = loadSessionData()[sid]?.scroll ?? 0
+          const { parentSid, isChild } = resolveParent(sid)
+          const data = loadSessionData()
+          const saved = isChild
+            ? data[parentSid]?.children?.[sid]?.scroll ?? 0
+            : data[sid]?.scroll ?? 0
           setScrollOffset(saved)
+          // 刷新父会话的访问时间 TTL，防止活跃会话的数据过期
+          if (!isChild && data[sid]?.entries?.length) {
+            data[sid].ts = Date.now()
+            saveSessionData(data)
+          }
         }
         // scan uses setEntryMapRaw — ephemeral data, not persisted to kv.
         // Only event-driven changes (handlePartUpdated, handleSessionEnd) persist.
@@ -1754,7 +1830,8 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
       description: "Mark all running sub-agent entries as done (for stuck/zombie entries)",
       slash: { name: "subagent-clear-running" },
       onSelect: (dialog) => {
-        const entries = globalEntryCache.get(signals.sessionId)
+        const sid = signals.sessionId
+        const entries = globalEntryCache.get(sid)
         if (!entries || entries.size === 0) {
           const msg = signals.lang() === "zh" ? "暂无子代理条目" : "No sub-agent entries found"
           api.ui.toast({ message: msg })
@@ -1773,11 +1850,21 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
           // 立即写 KV
           try {
             const data = JSON.parse(String(api.kv.get(`${KV_PREFIX}.session_data`, "{}")))
-            data[signals.sessionId] = {
-              ts: Date.now(),
-              entries: [...entries.values()],
-              scroll: data[signals.sessionId]?.scroll ?? 0,
-              expanded: data[signals.sessionId]?.expanded ?? "",
+            const sessionObj = api.state.session.get(sid)
+            const parentID = (sessionObj as any)?.parentID as string | undefined
+            if (parentID) {
+              if (!data[parentID]) data[parentID] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
+              if (!data[parentID].children) data[parentID].children = {}
+              if (!data[parentID].children[sid]) data[parentID].children[sid] = { scroll: 0, expanded: "", entries: [] }
+              data[parentID].children[sid] = { ...data[parentID].children[sid], entries: [...entries.values()] }
+            } else {
+              data[sid] = {
+                ts: Date.now(),
+                entries: [...entries.values()],
+                scroll: data[sid]?.scroll ?? 0,
+                expanded: data[sid]?.expanded ?? "",
+                children: data[sid]?.children ?? {},
+              }
             }
             api.kv.set(`${KV_PREFIX}.session_data`, JSON.stringify(data))
           } catch {}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -91,6 +91,7 @@ const I18N: Record<Lang, Record<string, string>> = {
     "ttl.toast_unlimited": "清理周期已设为无期限",
     "clear.title": "确认清除",
     "clear.prompt": "确定清除当前会话所有子代理记录？此操作不可撤销。",
+    "clear.prompt_running": "当前有 {n} 个运行中的子代理，清除后将不可恢复。确定继续？",
     "clear.done": "已清除 {n} 条子代理记录",
     "clear.empty": "当前会话无子代理记录",
   },
@@ -129,6 +130,7 @@ const I18N: Record<Lang, Record<string, string>> = {
     "ttl.toast_unlimited": "TTL set to Never",
     "clear.title": "Confirm",
     "clear.prompt": "Clear all sub-agent records for this session? This cannot be undone.",
+    "clear.prompt_running": "{n} sub-agent(s) are still running. Clearing will discard them permanently. Continue?",
     "clear.done": "Cleared {n} sub-agent record(s)",
     "clear.empty": "No sub-agent records in this session",
   },
@@ -1965,10 +1967,19 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
         const sid = signals.sessionId
         const sessionObj = api.state.session.get(sid)
         const parentID = (sessionObj as any)?.parentID as string | undefined
+        // 检查是否存在运行中的条目
+        const cached = globalEntryCache.get(sid)
+        let runningCount = 0
+        if (cached) {
+          for (const [, e] of cached) { if (e.status === "running") runningCount++ }
+        }
+        const msg = runningCount > 0
+          ? t("clear.prompt_running").replace("{n}", String(runningCount))
+          : t("clear.prompt")
         dialog?.replace(() => (
           <api.ui.DialogConfirm
             title={t("clear.title")}
-            message={t("clear.prompt")}
+            message={msg}
             onConfirm={() => {
               try {
                 const data = JSON.parse(String(api.kv.get(`${KV_PREFIX}.session_data`, "{}")))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,9 @@ const I18N: Record<Lang, Record<string, string>> = {
     "ttl.7d": "7 天",
     "ttl.14d": "14 天",
     "ttl.30d": "30 天",
+    "ttl.unlimited": "无期限",
     "ttl.toast": "清理周期已设为 {n} 天",
+    "ttl.toast_unlimited": "清理周期已设为无期限",
     "clear.title": "确认清除",
     "clear.prompt": "确定清除当前会话所有子代理记录？此操作不可撤销。",
     "clear.done": "已清除 {n} 条子代理记录",
@@ -122,7 +124,9 @@ const I18N: Record<Lang, Record<string, string>> = {
     "ttl.7d": "7 days",
     "ttl.14d": "14 days",
     "ttl.30d": "30 days",
+    "ttl.unlimited": "Never",
     "ttl.toast": "TTL set to {n} days",
+    "ttl.toast_unlimited": "TTL set to Never",
     "clear.title": "Confirm",
     "clear.prompt": "Clear all sub-agent records for this session? This cannot be undone.",
     "clear.done": "Cleared {n} sub-agent record(s)",
@@ -302,7 +306,8 @@ function SubAgentPanel(props: {
 
   // ── session data (single-key, true deletion on cleanup) ──
   const SESSION_DATA_KEY = `${KV_PREFIX}.session_data`
-  const ttlDays = parseInt(String(props.api.kv.get(`${KV_PREFIX}.ttl_days`, "3")), 10) || 3
+  const ttlDaysRaw = parseInt(String(props.api.kv.get(`${KV_PREFIX}.ttl_days`, "3")), 10)
+  const ttlDays = Number.isNaN(ttlDaysRaw) ? 3 : ttlDaysRaw
   const TTL_MS = ttlDays * 24 * 60 * 60 * 1000
 
   interface ChildRecord {
@@ -411,6 +416,7 @@ function SubAgentPanel(props: {
   }
 
   const cleanupOldSessions = () => {
+    if (ttlDays <= 0) return  // 无期限，跳过清理
     try {
       const data = loadSessionData()
       const cutoff = Date.now() - TTL_MS
@@ -1930,11 +1936,12 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
               { title: t("ttl.7d"), value: "7" },
               { title: t("ttl.14d"), value: "14" },
               { title: t("ttl.30d"), value: "30" },
+              { title: t("ttl.unlimited"), value: "0" },
             ]}
             onSelect={(opt) => {
               const days = parseInt(opt.value, 10)
               api.kv.set(`${KV_PREFIX}.ttl_days`, String(days))
-              const msg = t("ttl.toast").replace("{n}", String(days))
+              const msg = days === 0 ? t("ttl.toast_unlimited") : t("ttl.toast").replace("{n}", String(days))
               api.ui.toast({ message: msg })
               dialog?.clear()
             }}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,6 +309,7 @@ function SubAgentPanel(props: {
     scroll: number
     expanded: string
     entries: SubEntry[]
+    cleared?: boolean
   }
 
   interface SessionRecord {
@@ -317,6 +318,7 @@ function SubAgentPanel(props: {
     scroll: number
     expanded: string
     children: Record<string, ChildRecord>
+    cleared?: boolean
   }
 
   const loadSessionData = (): Record<string, SessionRecord> => {
@@ -367,9 +369,9 @@ function SubAgentPanel(props: {
           if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
           if (!data[parentSid].children) data[parentSid].children = {}
           if (!data[parentSid].children[sid]) data[parentSid].children[sid] = { scroll: 0, expanded: "", entries: [] }
-          data[parentSid].children[sid] = { ...data[parentSid].children[sid], entries: [...entries.values()] }
+          data[parentSid].children[sid] = { ...data[parentSid].children[sid], entries: [...entries.values()], cleared: false }
         } else {
-          data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()], children: data[sid]?.children ?? {} }
+          data[sid] = { ...data[sid], ts: Date.now(), entries: [...entries.values()], children: data[sid]?.children ?? {}, cleared: false }
         }
         saveSessionData(data)
       } catch {}
@@ -454,9 +456,9 @@ function SubAgentPanel(props: {
             if (!data[parentSid]) data[parentSid] = { ts: Date.now(), entries: [], scroll: 0, expanded: "", children: {} }
             if (!data[parentSid].children) data[parentSid].children = {}
             if (!data[parentSid].children[props.sessionId]) data[parentSid].children[props.sessionId] = { scroll: 0, expanded: "", entries: [] }
-            data[parentSid].children[props.sessionId] = { ...data[parentSid].children[props.sessionId], entries: [...next.values()] }
+            data[parentSid].children[props.sessionId] = { ...data[parentSid].children[props.sessionId], entries: [...next.values()], cleared: false }
           } else {
-            data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()], children: data[props.sessionId]?.children ?? {} }
+            data[props.sessionId] = { ...data[props.sessionId], ts: Date.now(), entries: [...next.values()], children: data[props.sessionId]?.children ?? {}, cleared: false }
           }
           saveSessionData(data)
         } catch {}
@@ -1001,6 +1003,11 @@ function SubAgentPanel(props: {
           const next = switched
             ? new Map(globalEntryCache.get(sid) ?? loadEntries(sid))
             : new Map(prev)
+          // 被手动清除的会话跳过消息扫描重建，仅保留事件驱动新增的条目
+          const { parentSid, isChild } = resolveParent(sid)
+          const parentRec = loadSessionData()[parentSid]
+          const activeRec = isChild ? parentRec?.children?.[sid] : parentRec
+          if (activeRec?.cleared) return next
           try {
             const msgs = props.api.state.session.messages(sid)
             if (msgs && (msgs as any[]).length) {
@@ -1957,6 +1964,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
                     data[parentID].children[sid].entries = []
                     data[parentID].children[sid].scroll = 0
                     data[parentID].children[sid].expanded = ""
+                    data[parentID].children[sid].cleared = true
                   }
                 } else {
                   count = data[sid]?.entries?.length ?? 0
@@ -1964,6 +1972,7 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
                     data[sid].entries = []
                     data[sid].scroll = 0
                     data[sid].expanded = ""
+                    data[sid].cleared = true
                   }
                 }
                 api.kv.set(`${KV_PREFIX}.session_data`, JSON.stringify(data))

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -286,6 +286,9 @@ function safeErrorMsg(err: unknown): string {
 // 模块级缓存：各 session 的 entry 状态独立存储，不随当前视图切换而清除。
 const globalEntryCache = new Map<string, Map<string, SubEntry>>()
 
+// 模块级刷新信号：外部（如斜杠命令）触发清除后 +1，组件 scan 依赖它以重扫。
+const [clearTick, setClearTick] = createSignal(0)
+
 function SubAgentPanel(props: {
   theme: TuiThemeCurrent
   api: TuiPluginApi
@@ -977,6 +980,7 @@ function SubAgentPanel(props: {
     lastSid = sid
     const t = setTimeout(() => {
       untrack(() => {
+        void clearTick() // 外部触发的清除事件 → 重扫
         if (switched) {
           const { parentSid, isChild } = resolveParent(sid)
           const data = loadSessionData()
@@ -1963,6 +1967,8 @@ const tui: TuiPlugin = async (api: TuiPluginApi) => {
                   }
                 }
                 api.kv.set(`${KV_PREFIX}.session_data`, JSON.stringify(data))
+                globalEntryCache.delete(sid)
+                setClearTick((v) => v + 1)
                 const msg = t("clear.done").replace("{n}", String(count))
                 api.ui.toast({ message: msg })
               } catch {}


### PR DESCRIPTION
## 嵌套 KV 结构

`subagent_magazine.session_data` 从扁平改为嵌套：

- 父（主）会话为顶层 key，子会话 `scroll`/`expanded`/`entries` 存入 `children[childSid]`
- `resolveParent(sid)` 通过 SDK `parentID` 判断归属
- 访问时间 TTL：每次切回主会话刷新 `ts`，默认 3 天不过期

## 新命令

### /subagent-ttl
配置数据保留期限：**3 天 / 7 天 / 14 天 / 30 天 / 无期限**。弹框标题显示当前值。

### /subagent-clear-entries
清除当前会话全部子代理记录，使用 `clearedIds` 列表阻止扫描重建。
- 条目级跳过 —— 旧条目不上屏，新条目正常创建
- 有运行中条目时弹警告
- 内存缓存 + 组件同步刷新

## 修复

- clear-entries 同步清理 `globalEntryCache` 并触发组件重扫
- `clearTick` 信号移到 `untrack` 外修复依赖追踪，`forceReload` 防止 copy prev
- `|| 3` 吞零 bug —— 改用 `Number.isNaN` 支持值 0（无期限）
