### PR TITLE
fix(subagent): 兼容 OpenCode 原生 background 参数

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -665,7 +665,7 @@ function SubAgentPanel(props: {
       // Background tasks: tool completion ≠ agent completion — keep running until session.idle
       // Only keep running if state metadata confirms a child session was spawned;
       // otherwise (failed spawn, invalid agent) mark as done so the entry isn't stuck forever.
-      if (input?.run_in_background === true && status === "done") {
+      if ((input?.run_in_background === true || input?.background === true) && status === "done") {
         const stMetaCheck = st?.metadata as Record<string, unknown> | undefined
         const hasChild = stMetaCheck?.session_id !== undefined || stMetaCheck?.sessionId !== undefined
         if (hasChild) status = "running"
@@ -1057,7 +1057,7 @@ function SubAgentPanel(props: {
                     if (rawStatus === "completed") status = "done"
                     // Background tasks: tool completion ≠ agent completion — keep running until session.idle
                     // Only keep running if state metadata confirms a child session was spawned.
-                    if ((st?.input as Record<string, unknown> | undefined)?.run_in_background === true && status === "done") {
+                    if (((st?.input as Record<string, unknown> | undefined)?.run_in_background === true || (st?.input as Record<string, unknown> | undefined)?.background === true) && status === "done") {
                       const scanStMeta = st?.metadata as Record<string, unknown> | undefined
                       const scanHasChild = scanStMeta?.session_id !== undefined || scanStMeta?.sessionId !== undefined
                       if (scanHasChild) status = "running"


### PR DESCRIPTION
## 修改说明

OMOS 2.2.1 使用 OpenCode 原生的
`task(..., background: true)` 启动后台子代理。

`task` 工具启动子 session 后会先返回 `completed`。这时子 session
通常还在运行，所以 SubAgent Magazine 需要继续把条目保持为
`running`。

目前代码只识别旧参数 `run_in_background: true`，没有处理
`background: true`。这会导致 OMOS 启动的任务被提前显示为
`done`。

本次修改在两个状态处理位置同时兼容这两个参数：

- 实时 tool part 更新
- 历史消息扫描恢复

原有的 `session_id` / `sessionId` 检查保持不变。只有确认子 session
已经创建，条目才会继续保持 `running`，因此启动失败的任务不会一直
卡住。

## 验证

- `npm run typecheck`
- `npm run build`
- 使用 OMOS 2.2.1 启动真实后台任务
- 任务运行期间保持 `running`
- 子 session 进入 idle 后正常变成 `done`
- 原有 `run_in_background` 行为不变

Closes #11
